### PR TITLE
fix: added batch call + delete useless on-chain call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ coverage
 
 # environment variables
 .env
+
+# IDE
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,3 @@ coverage
 
 # environment variables
 .env
-
-# IDE
-.idea

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export async function parseSwap({
   transactionHash: Address;
   smartContractWallet?: Address;
 }) {
-  const chainId = await publicClient.getChainId();
+  const chainId = publicClient.chain.id;
 
   if (!isChainIdSupported(chainId)) {
     throw new Error(`chainId ${chainId} is unsupported…`);
@@ -46,9 +46,11 @@ export async function parseSwap({
     },
   }));
 
-  const trace = await client.traceCall({ hash });
-
-  const transaction = await publicClient.getTransaction({ hash });
+  const [trace, transaction, transactionReceipt] = await Promise.all([
+    client.traceCall({ hash }),
+    publicClient.getTransaction({ hash }),
+    publicClient.getTransactionReceipt({ hash }),
+  ]);
 
   const { from: taker, value, to } = transaction;
 
@@ -57,8 +59,6 @@ export async function parseSwap({
   const nativeAmountToTaker = calculateNativeTransfer(trace, {
     recipient: taker,
   });
-
-  const transactionReceipt = await publicClient.getTransactionReceipt({ hash });
 
   const isNativeSell = value > 0n;
 


### PR DESCRIPTION
## Improve efficiency and reliability 🏎️

Replaced `await publicClient.getChainId()` with direct access to `publicClient.chain.id` for a synchronous, faster retrieval of the current chain ID.

Batched network requests for `traceCall`, `getTransaction`, and `getTransactionReceipt` using `Promise.all` to reduce latency and improve performance. This avoids an unnecessary async call to fetch chain ID when the value is already available. Running all RPC calls in parallel speeds up `parseSwap`, especially under high-load or latency-sensitive conditions.