### PR TITLE
feat: log warning for reverted transactions

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -48,6 +48,24 @@ export const SETTLER_META_TXN_ABI = [
 
 export const FUNCTION_SELECTORS = { EXECUTE_META_TXN: "0xfd3ad6d4" };
 
+export const SUPPORTED_CHAINS = [
+  bsc,
+  base,
+  mode,
+  blast,
+  linea,
+  scroll,
+  mantle,
+  mainnet,
+  polygon,
+  arbitrum,
+  unichain,
+  optimism,
+  avalanche,
+  berachain,
+  worldchain,
+];
+
 export const NATIVE_SYMBOL_BY_CHAIN_ID: { [key in SupportedChainId]: string } =
   {
     [bsc.id]: bsc.nativeCurrency.symbol,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
   decodeFunctionData,
 } from "viem";
 import {
+  SUPPORTED_CHAINS,
   MULTICALL3_ADDRESS,
   FUNCTION_SELECTORS,
   ERC_4337_ENTRY_POINT,
@@ -59,6 +60,13 @@ export async function parseSwap({
   });
 
   const transactionReceipt = await publicClient.getTransactionReceipt({ hash });
+
+  if (transactionReceipt.status === "reverted") {
+    const chain = SUPPORTED_CHAINS.find((chain) => chain.id === chainId);
+    const message = `Unable to parse. Transaction ${hash} on ${chain?.name} has reverted.`;
+    console.warn(message);
+    return null;
+  }
 
   const isNativeSell = value > 0n;
 
@@ -159,7 +167,6 @@ export async function parseSwap({
         };
       } /* v8 ignore start */ else {
         // Unknown if this case actually happens. If it does, please file a bug report here: https://github.com/0xProject/0x-parser/issues/new/choose".
-        output = { symbol: "", amount: "", address: "" };
         console.error(
           "File a bug report here, including the expected results (URL to a block explorer) and the unexpected results: https://github.com/0xProject/0x-parser/issues/new/choose."
         );

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -19,7 +19,7 @@ import {
   worldchain,
   berachain,
 } from "viem/chains";
-import { test, expect } from "vitest";
+import { vi, test, expect } from "vitest";
 import { parseSwap } from "../index";
 import { NATIVE_TOKEN_ADDRESS } from "../constants";
 
@@ -1383,4 +1383,18 @@ test("parse a swap on Berachain (WETH for WBERA) with AllowanceHolder", async ()
       address: "0x6969696969696969696969696969696969696969",
     },
   });
+});
+
+// https://etherscan.io/tx/0x25f24a7e6ec93abc99dca56a0ef2de1999deb17f67e6ed91cad1271757fff810
+test("logs a warning for reverted transactions)", async () => {
+  const warnSpy = vi.spyOn(console, "warn");
+  const transactionHash = `0x25f24a7e6ec93abc99dca56a0ef2de1999deb17f67e6ed91cad1271757fff810`;
+  await parseSwap({ publicClient, transactionHash });
+
+  expect(warnSpy).toHaveBeenCalled();
+  expect(warnSpy).toHaveBeenCalledWith(
+    `Unable to parse. Transaction ${transactionHash} on Ethereum has reverted.`
+  );
+
+  warnSpy.mockRestore();
 });


### PR DESCRIPTION
The `parseSwap` function returns `null` when a transaction is reverted. Let's add a warning log to notify consumers when this happens.