### PR TITLE
feat: add support for monad

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@
         <br>Mantle
       </div>
     </td>
+        <td style="width:100px; text-align:center;">
+      <div align="center">
+        <img alt="mantle" src="https://raw.githubusercontent.com/rainbow-me/assets/master/blockchains/monad/info/logo.png" width="22"/>
+        <br>Monad
+      </div>
+    </td>
     <td style="width:100px; text-align:center;">
       <div align="center">
         <img alt="optimism" src="https://raw.githubusercontent.com/rainbow-me/assets/master/blockchains/optimism/info/logo.png" width="22"/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,15 +22,14 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "viem": "^2.37.7"
+        "viem": "^2.39.3"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
       "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -623,7 +622,6 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -636,7 +634,6 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
       "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.8.0"
       },
@@ -652,7 +649,6 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -983,7 +979,6 @@
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
       "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -993,7 +988,6 @@
       "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
       "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/curves": "~1.9.0",
         "@noble/hashes": "~1.8.0",
@@ -1008,7 +1002,6 @@
       "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
       "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "~1.8.0",
         "@scure/base": "~1.2.5"
@@ -1047,6 +1040,7 @@
       "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.12.0"
       }
@@ -1884,7 +1878,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "ws": "*"
       }
@@ -2121,7 +2114,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@adraffy/ens-normalize": "^1.11.0",
         "@noble/ciphers": "^1.3.0",
@@ -2145,8 +2137,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
@@ -2209,6 +2200,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2688,6 +2680,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2722,9 +2715,9 @@
       "dev": true
     },
     "node_modules/viem": {
-      "version": "2.37.7",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.37.7.tgz",
-      "integrity": "sha512-KmTK/xc6790I0V9iaiJz8C3RdGevpU+fPvg53eOlfEfsfz0wCypXqOlOmCcjzkpmf2XFoEtu9MAxhMqk8YdNNA==",
+      "version": "2.39.3",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.39.3.tgz",
+      "integrity": "sha512-s11rPQRvUEdc5qHK3xT4fIk4qvgPAaLwaTFq+EbFlcJJD+Xn3R4mc9H6B6fquEiHl/mdsdbG/uKCnYpoNtHNHw==",
       "funding": [
         {
           "type": "github",
@@ -2732,7 +2725,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/curves": "1.9.1",
         "@noble/hashes": "1.8.0",
@@ -2757,7 +2749,6 @@
       "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.1.0.tgz",
       "integrity": "sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/wevm"
       },
@@ -2780,6 +2771,7 @@
       "integrity": "sha512-SRYIB8t/isTwNn8vMB3MR6E+EQZM/WG1aKmmIUCfDXfVvKfc20ZpamngWHKzAmmu9ppsgxsg4b2I7c90JZudIQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -2878,6 +2870,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "test": "vitest --coverage"
   },
   "peerDependencies": {
-    "viem": "^2.37.7"
+    "viem": "^2.39.3"
   },
   "devDependencies": {
     "@types/node": "^24.5.2",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,7 @@ import {
   avalanche,
   berachain,
   worldchain,
+  monad
 } from "viem/chains";
 import type { SupportedChainId } from "./types";
 
@@ -65,6 +66,7 @@ export const SUPPORTED_CHAINS = [
   avalanche,
   berachain,
   worldchain,
+  monad,
 ];
 
 export const NATIVE_SYMBOL_BY_CHAIN_ID: { [key in SupportedChainId]: string } =
@@ -76,6 +78,7 @@ export const NATIVE_SYMBOL_BY_CHAIN_ID: { [key in SupportedChainId]: string } =
     [linea.id]: linea.nativeCurrency.symbol,
     [scroll.id]: scroll.nativeCurrency.symbol,
     [mantle.id]: mantle.nativeCurrency.symbol,
+    [monad.id]: monad.nativeCurrency.symbol,
     [plasma.id]: plasma.nativeCurrency.symbol,
     [mainnet.id]: mainnet.nativeCurrency.symbol,
     [polygon.id]: polygon.nativeCurrency.symbol,

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ import {
   worldchain,
   berachain,
   unichain,
+  monad
 } from "viem/chains";
 
 import type {
@@ -31,6 +32,7 @@ export type SupportedChainId =
   | typeof bsc.id
   | typeof base.id
   | typeof mode.id
+  | typeof monad.id
   | typeof blast.id
   | typeof linea.id
   | typeof scroll.id

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -16,6 +16,7 @@ import {
   avalanche,
   berachain,
   worldchain,
+  monad
 } from "viem/chains";
 import { NATIVE_SYMBOL_BY_CHAIN_ID, NATIVE_TOKEN_ADDRESS } from "../constants";
 import type { Address } from "viem";
@@ -33,6 +34,7 @@ export function isChainIdSupported(
     bsc.id,
     base.id,
     mode.id,
+    monad.id,
     blast.id,
     linea.id,
     scroll.id,


### PR DESCRIPTION
## Context

Monad Mainnet launch is scheduled for November 24th, 2025 @ 9AM EST and we wish to add support to the 0x-parser for this chain.

Note: No tests were added as there are no methods available through alchemy at this time. Tests will need to be added once support is enabled. 
<img width="1117" height="541" alt="image" src="https://github.com/user-attachments/assets/ce76592b-b524-45fc-9d08-2117484fc815" />

