### PR TITLE
docs: fix etherscan URL path from /address/ to /tx/

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ async function main() {
   const RPC_URL = `https://eth-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`;
 
   // You can pass any transaction hash that you got after submitted a 0x transaction:
-  // https://etherscan.io/address/0x2fc205711fc933ef6e5bcc0bf6e6a9bfc220b2d8073aea4f41305882f485669d
+  // https://etherscan.io/tx/0x2fc205711fc933ef6e5bcc0bf6e6a9bfc220b2d8073aea4f41305882f485669d
   const transactionHash = `0x2fc205711fc933ef6e5bcc0bf6e6a9bfc220b2d8073aea4f41305882f485669d`;
 
   const publicClient = createPublicClient({


### PR DESCRIPTION
## Summary

Fixed a typo in the README.md Usage example where the Etherscan URL path incorrectly used `/address/` instead of `/tx/` for the transaction link.

## Changes

- **Before:** `// https://etherscan.io/address/0x2fc205711fc933ef6e5bcc0bf6e6a9bfc220b2d8073aea4f41305882f485669d`
- **After:** `// https://etherscan.io/tx/0x2fc205711fc933ef6e5bcc0bf6e6a9bfc220b2d8073aea4f41305882f485669d`

## Why

The URL is referencing a transaction hash, so it should use Etherscan's `/tx/` path (for transactions), not `/address/` (which is for wallet/contract addresses).