### PR TITLE
fix: bump github actions to node24 runtimes

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -13,11 +13,11 @@ jobs:
           release-type: node
           package-name: "@0x/0x-parser"
       # The logic below handles the npm publication:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         # these if statements ensure that a publication only occurs when
         # a new release is created:
         if: ${{ steps.release.outputs.release_created }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: 22.x
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - run: npm ci
       - run: npm run build
       - run: npm test --coverage
@@ -19,7 +19,7 @@ jobs:
           QUICKNODE_BNB_CHAIN_API_KEY: ${{ secrets.QUICKNODE_BNB_CHAIN_API_KEY }}
           QUICKNODE_MODE_API_KEY: ${{ secrets.QUICKNODE_MODE_API_KEY }}
           QUICKNODE_ABSTRACT_API_KEY: ${{ secrets.QUICKNODE_ABSTRACT_API_KEY }}
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./coverage/


### PR DESCRIPTION
GitHub is removing Node ≤20 action runtimes from Actions runners on 2026-09-16, with a forced Node 24 default starting 2026-06-16 ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Actions updated to their Node 24 releases:

- `actions/checkout` v3 → v6
- `actions/setup-node` v3 → v6
- `codecov/codecov-action` v3 → v7