### PR TITLE
feat: add support for Robinhood chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@
   <tr>
     <td style="width:100px; text-align:center;">
       <div align="center">
+        <img alt="Robinhood Chain" src="https://robinhood.com/favicon.ico" width="24"/>
+        <br>Robinhood
+      </div>
+    </td>
+    <td style="width:100px; text-align:center;">
+      <div align="center">
         <img alt="coming soon" src="https://i.imgur.com/CexTjqF.png" width="22"/>
         <br>🔜
       </div>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,4 @@
+import { defineChain } from "viem";
 import {
   bsc,
   base,
@@ -19,6 +20,25 @@ import {
   abstract,
 } from "viem/chains";
 import type { SupportedChainId } from "./types";
+
+// Robinhood Chain is not exported from viem/chains, so we define it locally.
+export const robinhoodChain = defineChain({
+  id: 4663,
+  name: "Robinhood Chain",
+  nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+  rpcUrls: {
+    default: { http: ["https://rpc.chain.robinhood.com"] },
+  },
+  blockExplorers: {
+    default: {
+      name: "Blockscout",
+      url: "https://robinhoodchain.blockscout.com",
+    },
+  },
+  contracts: {
+    multicall3: { address: "0xca11bde05977b3631167028862be2a173976ca11" },
+  },
+});
 
 
 export const FORWARDING_MULTICALL_ABI = [
@@ -134,6 +154,7 @@ export const SUPPORTED_CHAINS = [
   worldchain,
   monad,
   abstract,
+  robinhoodChain,
 ];
 
 export const NATIVE_SYMBOL_BY_CHAIN_ID: { [key in SupportedChainId]: string } =
@@ -156,6 +177,7 @@ export const NATIVE_SYMBOL_BY_CHAIN_ID: { [key in SupportedChainId]: string } =
     [berachain.id]: berachain.nativeCurrency.symbol,
     [worldchain.id]: worldchain.nativeCurrency.symbol,
     [abstract.id]: abstract.nativeCurrency.symbol,
+    [robinhoodChain.id]: robinhoodChain.nativeCurrency.symbol,
   };
 
 export const NATIVE_TOKEN_ADDRESS = `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ import {
   monad,
   abstract,
 } from "viem/chains";
+import { robinhoodChain } from "./constants";
 
 import type {
   Hex,
@@ -47,7 +48,8 @@ export type SupportedChainId =
   | typeof avalanche.id
   | typeof berachain.id
   | typeof worldchain.id
-  | typeof abstract.id;
+  | typeof abstract.id
+  | typeof robinhoodChain.id;
 
 export interface EnrichLogsArgs {
   transactionReceipt: TransactionReceipt;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -19,7 +19,11 @@ import {
   monad,
   abstract,
 } from "viem/chains";
-import { NATIVE_SYMBOL_BY_CHAIN_ID, NATIVE_TOKEN_ADDRESS } from "../constants";
+import {
+  NATIVE_SYMBOL_BY_CHAIN_ID,
+  NATIVE_TOKEN_ADDRESS,
+  robinhoodChain,
+} from "../constants";
 import type { Address } from "viem";
 import type {
   Trace,
@@ -50,6 +54,7 @@ export function isChainIdSupported(
     berachain.id,
     worldchain.id,
     abstract.id,
+    robinhoodChain.id,
   ];
   return supportedChainIds.includes(chainId);
 }


### PR DESCRIPTION
## Problem

`0x-parser` did not support Robinhood Chain (chainId `4663`, an Arbitrum Orbit L2 with ETH gas). Calling `parseSwap` for a Robinhood transaction threw `chainId 4663 is unsupported`.

## Solution

Mirrors the Abstract chain addition (#97). Robinhood Chain is not exported from `viem/chains`, so it is defined locally with `defineChain`, including the canonical Multicall3 (`0xca11…ca11`, verified on-chain) which viem's `multicall` requires when enriching transfer logs.

- `src/constants.ts` — define and export `robinhoodChain`; add to `SUPPORTED_CHAINS` and `NATIVE_SYMBOL_BY_CHAIN_ID`.
- `src/types.ts` — add `typeof robinhoodChain.id` to the `SupportedChainId` union.
- `src/utils/index.ts` — add `robinhoodChain.id` to `isChainIdSupported`.
- `README.md` — add Robinhood to the blockchain support table.

### Validation

- `npm run build` (esbuild cjs + esm) and `tsc --emitDeclarationOnly` both pass.
- Runtime smoke test confirms `id: 4663`, native symbol `ETH`, membership in `SUPPORTED_CHAINS`, and `isChainIdSupported(4663) === true`.

### Not included: integration test

Every chain here has a live integration test needing a real 0x Settler swap tx and an RPC exposing `debug_traceTransaction`. Neither is available for Robinhood yet: Alchemy/Quicknode don't support chainId 4663, the public RPC (`rpc.chain.robinhood.com`) rejects non-browser TLS and doesn't expose debug tracing, and the Blockscout explorer is behind HTTP auth. This matches the repo's own history — the Abstract feature PR (#97) added the code and the test-provider wiring landed separately (#99) once a debug RPC existed. A follow-up will add the test once a debug-capable RPC for 4663 and a real swap tx are available.