### PR TITLE
fix: include plasma in SUPPORTED_CHAINS

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -124,6 +124,7 @@ export const SUPPORTED_CHAINS = [
   linea,
   scroll,
   mantle,
+  plasma,
   mainnet,
   polygon,
   arbitrum,


### PR DESCRIPTION
## Problem

`plasma` is declared as a supported chain in three places — the `SupportedChainId` union (`src/types.ts`), `NATIVE_SYMBOL_BY_CHAIN_ID`, and `isChainIdSupported` (`src/utils/index.ts`) — but it is missing from `SUPPORTED_CHAINS` in `src/constants.ts`.

`SUPPORTED_CHAINS` is used in `parseSwap` to resolve the chain name when a transaction has reverted:

```ts
const chain = SUPPORTED_CHAINS.find((chain) => chain.id === chainId);
const message = `Unable to parse. Transaction ${hash} on ${chain?.name} has reverted.`;
```

For a reverted Plasma transaction this logs `... on undefined has reverted.` even though the chain is otherwise fully supported.

## Solution

Add `plasma` to `SUPPORTED_CHAINS` so the chain is declared consistently across all four references. `plasma` is already imported in `constants.ts`, so this is a one-line addition.

### Validation

- `tsc --emitDeclarationOnly` passes.