### PR TITLE
fix: migrate release-please to googleapis/release-please-action@v5

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -7,11 +7,10 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           release-type: node
-          package-name: "@0x/0x-parser"
       # The logic below handles the npm publication:
       - uses: actions/checkout@v6
         # these if statements ensure that a publication only occurs when


### PR DESCRIPTION
GitHub removes Node ≤20 action runtimes from runners on 2026-09-16 — [changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). The old release-please action is archived on node16; the maintained fork runs on node24:

- `google-github-actions/release-please-action@v3` (node16, archived) → `googleapis/release-please-action@v5` (node24)
- dropped the removed `package-name` input (v5 reads it from `package.json`)

References
- https://linear.app/0xproject/issue/PLA-1666/upgrade-all-node-20-github-actions-org-wide-before-runner-removal